### PR TITLE
Add information on blobscaninfo LatestScan for blob triggers

### DIFF
--- a/articles/azure-functions/functions-bindings-storage-blob-trigger.md
+++ b/articles/azure-functions/functions-bindings-storage-blob-trigger.md
@@ -386,7 +386,7 @@ Azure Functions stores blob receipts in a container named *azure-webjobs-hosts* 
 * The blob name
 * The ETag (a blob version identifier, for example: "0x8D1DC6E70A277EF")
 
-To force reprocessing of a blob, delete the blob receipt for that blob from the *azure-webjobs-hosts* container manually. While reprocessing might not occur immediately, it's guaranteed to occur at a later point in time.
+To force reprocessing of a blob, delete the blob receipt for that blob from the *azure-webjobs-hosts* container manually. While reprocessing might not occur immediately, it's guaranteed to occur at a later point in time. To reprocess immediately, the *scaninfo* blob in *azure-webjobs-hosts/blobscaninfo* can be updated. Any blobs with a last modified timestamp after the `LatestScan` property will be scanned again.
 
 ## Poison blobs
 


### PR DESCRIPTION
This pull request adds a section explaning where to find the *scaninfo* file and how to change it to force an immediate rescan of the blob storage.

Ref #MicrosoftDocs/azure-docs#50660